### PR TITLE
Fixed generic modal event warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed generic modal event warning](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/23)
 - [Added custom notification support](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/21)
 
 ## [[0.0.0-alpha.1](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/16)] - 2025-01-20

--- a/src/common/generic-modal/generic-modal.tsx
+++ b/src/common/generic-modal/generic-modal.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, VNode, h } from '@stencil/core';
+import { Component, Event, EventEmitter, Prop, VNode, h } from '@stencil/core';
 
 @Component({
   tag: 'generic-modal',
@@ -9,14 +9,14 @@ export class GenericModal {
   @Prop() body: VNode;
   @Prop() modalTitle: string | VNode;
   @Prop() modalSubtitle?: string | VNode;
-  @Prop() onClose: () => void;
+  @Event() close: EventEmitter<void>;
 
   render() {
     return (
       <div class="modal">
         <div class="modal-content">
           <div class="modal-header">
-            <span class="close" onClick={this.onClose}>
+            <span class="close" onClick={() => this.close.emit()}>
               ✕
             </span>
             <h2>{this.modalTitle}</h2>

--- a/src/common/generic-modal/readme.md
+++ b/src/common/generic-modal/readme.md
@@ -12,7 +12,13 @@
 | `body`          | --               |             | `VNode`           | `undefined` |
 | `modalSubtitle` | `modal-subtitle` |             | `VNode \| string` | `undefined` |
 | `modalTitle`    | `modal-title`    |             | `VNode \| string` | `undefined` |
-| `onClose`       | --               |             | `() => void`      | `undefined` |
+
+
+## Events
+
+| Event   | Description | Type                |
+| ------- | ----------- | ------------------- |
+| `close` |             | `CustomEvent<void>` |
 
 
 ## Dependencies

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -46,7 +46,6 @@ export namespace Components {
         "body": VNode;
         "modalSubtitle"?: string | VNode;
         "modalTitle": string | VNode;
-        "onClose": () => void;
     }
     interface GenericSpinner {
     }
@@ -132,6 +131,10 @@ export interface CustomToastCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLCustomToastElement;
 }
+export interface GenericModalCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLGenericModalElement;
+}
 export interface GenericToastCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLGenericToastElement;
@@ -184,7 +187,18 @@ declare global {
         prototype: HTMLFungibleComponentElement;
         new (): HTMLFungibleComponentElement;
     };
+    interface HTMLGenericModalElementEventMap {
+        "close": void;
+    }
     interface HTMLGenericModalElement extends Components.GenericModal, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLGenericModalElementEventMap>(type: K, listener: (this: HTMLGenericModalElement, ev: GenericModalCustomEvent<HTMLGenericModalElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLGenericModalElementEventMap>(type: K, listener: (this: HTMLGenericModalElement, ev: GenericModalCustomEvent<HTMLGenericModalElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLGenericModalElement: {
         prototype: HTMLGenericModalElement;
@@ -387,7 +401,7 @@ declare namespace LocalJSX {
         "body"?: VNode;
         "modalSubtitle"?: string | VNode;
         "modalTitle"?: string | VNode;
-        "onClose"?: () => void;
+        "onClose"?: (event: GenericModalCustomEvent<void>) => void;
     }
     interface GenericSpinner {
     }


### PR DESCRIPTION
### Issue
Warning is shown on onClose prop from generic-modal

### Fix
change onClose from @Prop to @Event
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
