### PR TITLE
Refactor package compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Refactor package compile](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/57)
 - [Added gasPrice PPU editing radios](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/56)
 - [Added gasPrice editing radios](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/52)
 - [Added notifications feed side panel](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/50)

--- a/package.json
+++ b/package.json
@@ -12,12 +12,9 @@
   "unpkg": "dist/components/sdk-dapp-core-ui.esm.js",
   "exports": {
     ".": {
-      "import": "./dist/components/sdk-dapp-core-ui.esm.js",
-      "require": "./dist/components/sdk-dapp-core-ui.cjs.js"
-    },
-    "./dist/*": {
-      "import": "./dist/*",
-      "types": "./dist/*"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs.js",
+      "types": "./dist/types/index.d.ts"
     },
     "./components/*": {
       "import": "./dist/components/*.js",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -241,7 +241,7 @@ export namespace Components {
     }
     interface WalletConnect {
         "data": IWalletConnectModalData;
-        "getEventBus": () => Promise<import("/Users/tudor/Work/sdk-dapp-core-workspace/packages/mx-sdk-dapp-core-ui/src/components").IEventBus>;
+        "getEventBus": () => Promise<IEventBus>;
     }
     interface WalletConnectBody {
         "description": string;

--- a/src/components/functional/wallet-connect-components/wallet-connect.tsx
+++ b/src/components/functional/wallet-connect-components/wallet-connect.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, forceUpdate, h, Method, Prop, State, Watch } from '@stencil/core';
+import type { IEventBus } from 'utils/EventBus';
 
 import type { IWalletConnectModalData } from './wallet-connect-modal.types';
 import { WalletConnectBase } from './WalletConnectBase';
@@ -22,7 +23,7 @@ export class WalletConnect {
     this.walletConnectBase = new WalletConnectBase(this.data);
   }
 
-  @Method() async getEventBus() {
+  @Method() async getEventBus(): Promise<IEventBus> {
     return this.walletConnectBase.getEventBus();
   }
 

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -3,7 +3,6 @@ import { reactOutputTarget } from '@stencil/react-output-target';
 import nodePolyfills from 'rollup-plugin-node-polyfills';
 import { sass } from '@stencil/sass';
 import tailwind, { tailwindHMR } from 'stencil-tailwind-plugin';
-
 const excludeComponents = [
   'sign-transactions-modal',
   'transaction-fee-component',
@@ -30,23 +29,26 @@ const excludeComponents = [
   'fungible-component',
   'balance-component',
 ];
-
 export const config: Config = {
   namespace: 'sdk-dapp-core-ui',
   plugins: [sass(), tailwind(), tailwindHMR()],
   outputTargets: [
     reactOutputTarget({
       outDir: './dist/react',
+      customElementsDir: './dist/components',
       excludeComponents,
     }),
-    {
-      type: 'dist',
-      esmLoaderPath: '../loader',
-    },
+
     {
       type: 'dist-custom-elements',
       externalRuntime: false,
       generateTypeDeclarations: true,
+      dir: './dist/components',
+    },
+
+    {
+      type: 'dist',
+      esmLoaderPath: '../loader',
     },
     {
       type: 'docs-readme',
@@ -61,5 +63,8 @@ export const config: Config = {
   },
   rollupPlugins: {
     after: [nodePolyfills()],
+  },
+  extras: {
+    enableImportInjection: true,
   },
 };

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -35,7 +35,7 @@ export const config: Config = {
   outputTargets: [
     reactOutputTarget({
       outDir: './dist/react',
-      customElementsDir: './dist/components',
+      customElementsDir: 'dist/components',
       excludeComponents,
     }),
 


### PR DESCRIPTION
### Issue
Stencil components are not added seen by bundlers like Vite on runtime

### Reproduce
When we use skd-dapp-core-ui inside of a dapp created with Vite and we don't exclude it from optimizeDeps: like this 
```
optimizeDeps: {
    exclude: ['@multiversx/sdk-dapp-core-ui'] // Prevent Vite from trying to pre-bundle it
  }, 
```
 not all components will be loaded in bundle at runtime.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
