### PR TITLE
Add polllyfils before build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix stencil-tailwind-plugin build error in monorepo](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/79)
+
 ## [[0.0.0-alpha.12](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/78)] - 2025-04-10
 
 - [Add stencil-tailwind-plugin for tailwind v4](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/77)

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -64,7 +64,7 @@ export const config: Config = {
     // },
   ],
   rollupPlugins: {
-    after: [nodePolyfills()],
+    before: [nodePolyfills()],
   },
   extras: {
     enableImportInjection: true,


### PR DESCRIPTION
### Issue
Using stencil-tailwind-plugin in a monorepo environment causes a build failure when PostCSS attempts to parse a JavaScript file (object.assign/polyfill.js) as CSS, resulting in a CssSyntaxError.

### Reproduce
Issue exists on version `0.0.0-alpha.12` of sdk-dapp-core-ui.

### Root cause
In a monorepo, symlinked packages and shared module resolution can cause postcss (via stencil-tailwind-plugin) to inadvertently process JavaScript files (e.g., from node_modules) as CSS.
Because nodePolyfills() was registered under rollupPlugins.after, the polyfills were applied after Stencil's internal plugins ran — too late to prevent the PostCSS crash.

### Fix
Move nodePolyfills() to the rollupPlugins.before array in stencil.config.ts to ensure polyfills are available before any Stencil or plugin transformations begin.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
