### PR TITLE
Fixed sign transactions button states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed sign transactions button states](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/87)
 - [Fixed bubbling events](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/86)
 - [Updated the Ledger authentication flow layout](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/85)
 - [Added cancel login](https://github.com/multiversx/mx-sdk-dapp-core-ui/pull/84)

--- a/src/components/functional/sign-transactions-panel/sign-transactions-panel.css
+++ b/src/components/functional/sign-transactions-panel/sign-transactions-panel.css
@@ -14,7 +14,6 @@
   width: 450px;
   max-width: 100%;
   padding: 0;
-  background-color: #ffffff;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
@@ -46,4 +45,11 @@
 .sign-transactions-body {
   flex: 1;
   overflow-y: auto;
+}
+
+
+.sign-transactions-panel,
+.sign-transactions-header *,
+.sign-transactions-body * {
+  color: #ffffff !important;
 }

--- a/src/components/functional/sign-transactions-panel/sign-transactions-panel.tsx
+++ b/src/components/functional/sign-transactions-panel/sign-transactions-panel.tsx
@@ -7,10 +7,10 @@ import { SignEventsEnum } from './sign-transactions-panel.types';
 import state, { resetState } from './signTransactionsPanelStore';
 
 const signScreens = {
-  FungibleESDT: 'token-component',
-  SemiFungibleESDT: 'fungible-component',
-  NonFungibleESDT: 'fungible-component',
-  MetaESDT: 'token-component',
+  FungibleESDT: 'mvx-token-component',
+  SemiFungibleESDT: 'mvx-fungible-component',
+  NonFungibleESDT: 'mvx-fungible-component',
+  MetaESDT: 'mvx-token-component',
 };
 
 @Component({

--- a/src/components/functional/sign-transactions-panel/sign-transactions-panel.types.ts
+++ b/src/components/functional/sign-transactions-panel/sign-transactions-panel.types.ts
@@ -40,6 +40,7 @@ export interface ISignTransactionsPanelCommonData {
   highlight?: string | null;
   scCall?: string | null;
   nextUnsignedTxIndex?: number;
+  providerName?: string;
 }
 
 export interface ISignTransactionsPanelData {


### PR DESCRIPTION
### Issue
- Sign button is not disabled during signing
- No relevant meesage is shown during signing
- Nothing is shown during signing
- Text is black on black background

### Fix
- Show `Confirm on PROVIDER` during signing and disable the button
- Make text white
- Fixed incorrect sign transaction components tag names

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
